### PR TITLE
Fix global leak

### DIFF
--- a/dist/js-data-sql.js
+++ b/dist/js-data-sql.js
@@ -186,6 +186,7 @@ module.exports =
 	  function DSSqlAdapter(options) {
 	    _classCallCheck(this, DSSqlAdapter);
 
+	    this.defaults = {};
 	    options = options || {};
 	    if (options.__knex__) {
 	      this.query = options;

--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,7 @@ function filterQuery(resourceConfig, params) {
 
 class DSSqlAdapter {
   constructor(options) {
+    this.defaults = {};
     options = options || {};
     if (options.__knex__) {
       this.query = options;


### PR DESCRIPTION
Ensure `this.defaults` is set to an object to prevent global leak. Fixes #13.

Thanks.