### PR TITLE
Do not return relation columns on parent when performing filter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function getTable (resourceConfig) {
 }
 
 function filterQuery (resourceConfig, params) {
-  let query = this.query.select('*').from(getTable(resourceConfig))
+  let table = getTable(resourceConfig)
+  let query = this.query.select(`${table}.*`).from(table)
   params = params || {}
   params.where = params.where || {}
   params.orderBy = params.orderBy || params.sort

--- a/test/findAll.spec.js
+++ b/test/findAll.spec.js
@@ -172,4 +172,14 @@ describe('DSSqlAdapter#findAll', function () {
     var user = yield adapter.findAll(User, {limit: '10', offset: '20'});
   });
 
+  it('should not return relation columns on parent', function* () {
+    var profile1 = yield adapter.create(Profile, { email: 'foo@test.com' });
+    var user1 = yield adapter.create(User, {name: 'John', profileId: profile1.id});
+
+    var users = yield adapter.findAll(User, {'profile.email': 'foo@test.com'});
+    assert.equal(users.length, 1);
+    assert.equal(users[0].profileId, profile1.id);
+    assert.isUndefined(users[0].email);
+  });
+
 });


### PR DESCRIPTION
When filtering across relations (and thus performing joins), the relation's columns were being leaked onto the parent.