### PR TITLE
Fix tests to actually run (not just pass)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "lint": "node_modules/standard/bin/cmd.js src/index.js",
     "build": "node_modules/webpack/bin/webpack.js --config webpack.config.js --progress --colors",
-    "mocha": "mocha test/*.spec.js --timeout 20000 --reporter spec",
+    "mocha": "mocha --timeout 20000 --reporter spec mocha.start.js test/*.spec.js",
     "test": "npm run lint && npm run build && npm run mocha"
   },
   "standard": {


### PR DESCRIPTION
`mocha.start.js` wasn't being added, so `co-mocha` wasn't used, so generator function tests were passing without actually running