### PR TITLE
#10 - transaction support via knex

### DIFF
--- a/mocha.start.js
+++ b/mocha.start.js
@@ -38,7 +38,8 @@ var globals = module.exports = {
   }],
   TYPES_EXCEPT_FUNCTION: ['string', 123, 123.123, null, undefined, {}, [], true, false],
   assert: assert,
-  adapter: undefined
+  adapter: undefined,
+  co: require('co')
 };
 
 var test = new mocha();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-loader": "5.3.2",
     "bluebird": "2.10.2",
     "chai": "3.3.0",
+    "co": "^4.6.0",
     "co-mocha": "1.1.2",
     "mocha": "2.3.3",
     "standard": "5.3.1",

--- a/test/create_trx.spec.js
+++ b/test/create_trx.spec.js
@@ -1,0 +1,66 @@
+describe('DSSqlAdapter#create + transaction', function () {
+  it('commit should persist created user in a sql db', function* () {
+    var id;
+    var co = require('co');
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var createUser = yield adapter.create(User, {name: 'Jane'}, {transaction: trx});
+      id = createUser.id;
+      assert.equal(createUser.name, 'Jane');
+      assert.isDefined(createUser.id);
+
+      var findUser = yield adapter.find(User, createUser.id, {transaction: trx});
+      assert.equal(findUser.name, 'Jane');
+      assert.isDefined(findUser.id);
+      assert.equalObjects(findUser, {id: id, name: 'Jane', age: null, profileId: null});
+
+      return findUser;
+    })).then(
+      function (user) {
+        assert.isObject(user, 'transaction returned user object');
+        assert.equal(user.name, 'Jane');
+        assert.isDefined(user.id);
+        assert.equalObjects(user, {id: id, name: 'Jane', age: null, profileId: null});
+      },
+      function (err) {
+        throw new Error('transaction threw exception!');
+      }
+    );
+
+    try {
+      var findUser2 = yield adapter.find(User, id);
+      assert.isObject(findUser2, 'user committed to database');
+    } catch(err) {
+      throw new Error('transaction failed to commit!');
+    }
+  });
+
+  it('rollback should not persist created user in a sql db', function* () {
+    var id;
+    var co = require('co');
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var createUser = yield adapter.create(User, {name: 'John'}, {transaction: trx});
+      id = createUser.id;
+      assert.equal(createUser.name, 'John');
+      assert.isDefined(createUser.id);
+
+      var findUser = yield adapter.find(User, createUser.id, {transaction: trx});
+      assert.equal(findUser.name, 'John');
+      assert.isDefined(findUser.id);
+      assert.equalObjects(findUser, {id: id, name: 'John', age: null, profileId: null});
+
+      throw new Error('rollback');
+    })).then(
+      function () { throw new Error('transaction did not throw exception!') },
+      function (err) { assert.equal(err.message, 'rollback') }
+    );
+
+    try {
+      var findUser2 = yield adapter.find(User, id);
+      throw new Error('transaction failed to roll back!');
+    } catch(err) {
+      assert.equal(err.message, 'Not Found!');
+    }
+  });
+});

--- a/test/create_trx.spec.js
+++ b/test/create_trx.spec.js
@@ -1,64 +1,40 @@
 describe('DSSqlAdapter#create + transaction', function () {
   it('commit should persist created user in a sql db', function* () {
     var id;
-    var co = require('co');
 
     yield adapter.query.transaction(co.wrap(function * (trx) {
       var createUser = yield adapter.create(User, {name: 'Jane'}, {transaction: trx});
       id = createUser.id;
       assert.equal(createUser.name, 'Jane');
       assert.isDefined(createUser.id);
+    }));
 
-      var findUser = yield adapter.find(User, createUser.id, {transaction: trx});
-      assert.equal(findUser.name, 'Jane');
-      assert.isDefined(findUser.id);
-      assert.equalObjects(findUser, {id: id, name: 'Jane', age: null, profileId: null});
-
-      return findUser;
-    })).then(
-      function (user) {
-        assert.isObject(user, 'transaction returned user object');
-        assert.equal(user.name, 'Jane');
-        assert.isDefined(user.id);
-        assert.equalObjects(user, {id: id, name: 'Jane', age: null, profileId: null});
-      },
-      function (err) {
-        throw new Error('transaction threw exception!');
-      }
-    );
-
-    try {
-      var findUser2 = yield adapter.find(User, id);
-      assert.isObject(findUser2, 'user committed to database');
-    } catch(err) {
-      throw new Error('transaction failed to commit!');
-    }
+    var findUser = yield adapter.find(User, id);
+    assert.isObject(findUser, 'user committed to database');
+    assert.equal(findUser.name, 'Jane');
+    assert.isDefined(findUser.id);
+    assert.equalObjects(findUser, {id: id, name: 'Jane', age: null, profileId: null});
   });
 
   it('rollback should not persist created user in a sql db', function* () {
     var id;
-    var co = require('co');
-
-    yield adapter.query.transaction(co.wrap(function * (trx) {
-      var createUser = yield adapter.create(User, {name: 'John'}, {transaction: trx});
-      id = createUser.id;
-      assert.equal(createUser.name, 'John');
-      assert.isDefined(createUser.id);
-
-      var findUser = yield adapter.find(User, createUser.id, {transaction: trx});
-      assert.equal(findUser.name, 'John');
-      assert.isDefined(findUser.id);
-      assert.equalObjects(findUser, {id: id, name: 'John', age: null, profileId: null});
-
-      throw new Error('rollback');
-    })).then(
-      function () { throw new Error('transaction did not throw exception!') },
-      function (err) { assert.equal(err.message, 'rollback') }
-    );
 
     try {
-      var findUser2 = yield adapter.find(User, id);
-      throw new Error('transaction failed to roll back!');
+      yield adapter.query.transaction(co.wrap(function * (trx) {
+        var createUser = yield adapter.create(User, {name: 'John'}, {transaction: trx});
+        id = createUser.id;
+        assert.equal(createUser.name, 'John');
+        assert.isDefined(createUser.id);
+
+        throw new Error('rollback');
+      }));
+    } catch (err) {
+      assert.equal(err.message, 'rollback');
+    }
+
+    try {
+      var findUser = yield adapter.find(User, id);
+      throw new Error('user committed to database');
     } catch(err) {
       assert.equal(err.message, 'Not Found!');
     }

--- a/test/destroy_trx.spec.js
+++ b/test/destroy_trx.spec.js
@@ -1,0 +1,48 @@
+describe('DSSqlAdapter#destroy + transaction', function () {
+  it('commit should destroy a user from a Sql db', function* () {
+    var co = require('co');
+
+    var createUser = yield adapter.create(User, {name: 'John'})
+    var id = createUser.id;
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var destroyUser = yield adapter.destroy(User, createUser.id, {transaction: trx});
+      assert.isFalse(!!destroyUser);
+    }));
+
+    try {
+      var findUser = yield adapter.find(User, id);
+      throw new Error('Should not have reached here!');
+    } catch (err) {
+      assert.equal(err.message, 'Not Found!');
+    }
+  });
+
+  it('rollback should not destroy a user from a Sql db', function* () {
+    var co = require('co');
+
+    var createUser = yield adapter.create(User, {name: 'John'})
+    var id = createUser.id;
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var destroyUser = yield adapter.destroy(User, createUser.id, {transaction: trx});
+      assert.isFalse(!!destroyUser);
+
+      throw new Error('rollback');
+    })).then(
+      function () { throw new Error('transaction did not throw exception!') },
+      function (err) { assert.equal(err.message, 'rollback') }
+    );
+
+    try {
+      var findUser = yield adapter.find(User, id);
+      assert.isObject(findUser, 'user still exists');
+    } catch (err) {
+      if (err.message == 'Not Found!') {
+        throw new Error('transaction did not roll back');
+      } else {
+        throw new Error('caught exception trying to locate user');
+      }
+    }
+  });
+});

--- a/test/update_trx.spec.js
+++ b/test/update_trx.spec.js
@@ -1,93 +1,45 @@
 describe('DSSqlAdapter#update + transaction', function () {
   it('commit should update a user in a Sql db', function* () {
-    var co = require('co');
-
     var user = yield adapter.create(User, {name: 'John'})
     var id = user.id;
     assert.equal(user.name, 'John');
     assert.isDefined(user.id);
 
-    var foundUser = yield adapter.find(User, user.id);
-    assert.equal(foundUser.name, 'John');
-    assert.isDefined(foundUser.id);
-    assert.equalObjects(foundUser, {id: id, name: 'John', age: null, profileId: null});
-
     yield adapter.query.transaction(co.wrap(function * (trx) {
-      var updatedUser = yield adapter.update(User, foundUser.id, {name: 'Johnny'}, {transaction: trx});
+      var updatedUser = yield adapter.update(User, id, {name: 'Johnny'}, {transaction: trx});
       assert.equal(updatedUser.name, 'Johnny');
       assert.isDefined(updatedUser.id);
       assert.equalObjects(updatedUser, {id: id, name: 'Johnny', age: null, profileId: null});
+    }));
 
-      var foundUser2 = yield adapter.find(User, updatedUser.id, {transaction: trx});
-      assert.equal(foundUser2.name, 'Johnny');
-      assert.isDefined(foundUser2.id);
-      assert.equalObjects(foundUser2, {id: id, name: 'Johnny', age: null, profileId: null});
-
-      return foundUser2;
-    })).then(
-      function (user) { assert.isObject(user, 'transaction returned user object') },
-      function (err) { throw new Error('transaction threw exception!') }
-    );
-
-    var foundUser3 = yield adapter.find(User, user.id);
-    assert.equal(foundUser3.name, 'Johnny');
-    assert.isDefined(foundUser3.id);
-    assert.equalObjects(foundUser3, {id: id, name: 'Johnny', age: null, profileId: null});
-
-    var destroyUser = yield adapter.destroy(User, foundUser3.id);
-    assert.isFalse(!!destroyUser);
-
-    try {
-      yield adapter.find(User, id);
-      throw new Error('Should not have reached here!');
-    } catch (err) {
-      assert.equal(err.message, 'Not Found!');
-    }
+    var foundUser = yield adapter.find(User, id);
+    assert.equal(foundUser.name, 'Johnny');
+    assert.isDefined(foundUser.id);
+    assert.equalObjects(foundUser, {id: id, name: 'Johnny', age: null, profileId: null});
   });
 
   it('rollback should not update a user in a Sql db', function* () {
-    var co = require('co');
-
     var user = yield adapter.create(User, {name: 'John'})
     var id = user.id;
     assert.equal(user.name, 'John');
     assert.isDefined(user.id);
 
-    var foundUser = yield adapter.find(User, user.id);
+    try {
+      yield adapter.query.transaction(co.wrap(function * (trx) {
+        var updatedUser = yield adapter.update(User, id, {name: 'Johnny'}, {transaction: trx});
+        assert.equal(updatedUser.name, 'Johnny');
+        assert.isDefined(updatedUser.id);
+        assert.equalObjects(updatedUser, {id: id, name: 'Johnny', age: null, profileId: null});
+
+        throw new Error('rollback');
+      }));
+    } catch (err) {
+      assert.equal(err.message, 'rollback');
+    }
+
+    var foundUser = yield adapter.find(User, id);
     assert.equal(foundUser.name, 'John');
     assert.isDefined(foundUser.id);
     assert.equalObjects(foundUser, {id: id, name: 'John', age: null, profileId: null});
-
-    yield adapter.query.transaction(co.wrap(function * (trx) {
-      var updatedUser = yield adapter.update(User, foundUser.id, {name: 'Johnny'}, {transaction: trx});
-      assert.equal(updatedUser.name, 'Johnny');
-      assert.isDefined(updatedUser.id);
-      assert.equalObjects(updatedUser, {id: id, name: 'Johnny', age: null, profileId: null});
-
-      var foundUser2 = yield adapter.find(User, updatedUser.id, {transaction: trx});
-      assert.equal(foundUser2.name, 'Johnny');
-      assert.isDefined(foundUser2.id);
-      assert.equalObjects(foundUser2, {id: id, name: 'Johnny', age: null, profileId: null});
-
-      throw new Error('rollback');
-    })).then(
-      function () { throw new Error('transaction did not throw exception!') },
-      function (err) { assert.equal(err.message, 'rollback') }
-    );
-
-    var foundUser3 = yield adapter.find(User, user.id);
-    assert.equal(foundUser3.name, 'John');
-    assert.isDefined(foundUser3.id);
-    assert.equalObjects(foundUser3, {id: id, name: 'John', age: null, profileId: null});
-
-    var destroyUser = yield adapter.destroy(User, foundUser3.id);
-    assert.isFalse(!!destroyUser);
-
-    try {
-      yield adapter.find(User, id);
-      throw new Error('Should not have reached here!');
-    } catch (err) {
-      assert.equal(err.message, 'Not Found!');
-    }
   });
 });

--- a/test/update_trx.spec.js
+++ b/test/update_trx.spec.js
@@ -1,0 +1,93 @@
+describe('DSSqlAdapter#update + transaction', function () {
+  it('commit should update a user in a Sql db', function* () {
+    var co = require('co');
+
+    var user = yield adapter.create(User, {name: 'John'})
+    var id = user.id;
+    assert.equal(user.name, 'John');
+    assert.isDefined(user.id);
+
+    var foundUser = yield adapter.find(User, user.id);
+    assert.equal(foundUser.name, 'John');
+    assert.isDefined(foundUser.id);
+    assert.equalObjects(foundUser, {id: id, name: 'John', age: null, profileId: null});
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var updatedUser = yield adapter.update(User, foundUser.id, {name: 'Johnny'}, {transaction: trx});
+      assert.equal(updatedUser.name, 'Johnny');
+      assert.isDefined(updatedUser.id);
+      assert.equalObjects(updatedUser, {id: id, name: 'Johnny', age: null, profileId: null});
+
+      var foundUser2 = yield adapter.find(User, updatedUser.id, {transaction: trx});
+      assert.equal(foundUser2.name, 'Johnny');
+      assert.isDefined(foundUser2.id);
+      assert.equalObjects(foundUser2, {id: id, name: 'Johnny', age: null, profileId: null});
+
+      return foundUser2;
+    })).then(
+      function (user) { assert.isObject(user, 'transaction returned user object') },
+      function (err) { throw new Error('transaction threw exception!') }
+    );
+
+    var foundUser3 = yield adapter.find(User, user.id);
+    assert.equal(foundUser3.name, 'Johnny');
+    assert.isDefined(foundUser3.id);
+    assert.equalObjects(foundUser3, {id: id, name: 'Johnny', age: null, profileId: null});
+
+    var destroyUser = yield adapter.destroy(User, foundUser3.id);
+    assert.isFalse(!!destroyUser);
+
+    try {
+      yield adapter.find(User, id);
+      throw new Error('Should not have reached here!');
+    } catch (err) {
+      assert.equal(err.message, 'Not Found!');
+    }
+  });
+
+  it('rollback should not update a user in a Sql db', function* () {
+    var co = require('co');
+
+    var user = yield adapter.create(User, {name: 'John'})
+    var id = user.id;
+    assert.equal(user.name, 'John');
+    assert.isDefined(user.id);
+
+    var foundUser = yield adapter.find(User, user.id);
+    assert.equal(foundUser.name, 'John');
+    assert.isDefined(foundUser.id);
+    assert.equalObjects(foundUser, {id: id, name: 'John', age: null, profileId: null});
+
+    yield adapter.query.transaction(co.wrap(function * (trx) {
+      var updatedUser = yield adapter.update(User, foundUser.id, {name: 'Johnny'}, {transaction: trx});
+      assert.equal(updatedUser.name, 'Johnny');
+      assert.isDefined(updatedUser.id);
+      assert.equalObjects(updatedUser, {id: id, name: 'Johnny', age: null, profileId: null});
+
+      var foundUser2 = yield adapter.find(User, updatedUser.id, {transaction: trx});
+      assert.equal(foundUser2.name, 'Johnny');
+      assert.isDefined(foundUser2.id);
+      assert.equalObjects(foundUser2, {id: id, name: 'Johnny', age: null, profileId: null});
+
+      throw new Error('rollback');
+    })).then(
+      function () { throw new Error('transaction did not throw exception!') },
+      function (err) { assert.equal(err.message, 'rollback') }
+    );
+
+    var foundUser3 = yield adapter.find(User, user.id);
+    assert.equal(foundUser3.name, 'John');
+    assert.isDefined(foundUser3.id);
+    assert.equalObjects(foundUser3, {id: id, name: 'John', age: null, profileId: null});
+
+    var destroyUser = yield adapter.destroy(User, foundUser3.id);
+    assert.isFalse(!!destroyUser);
+
+    try {
+      yield adapter.find(User, id);
+      throw new Error('Should not have reached here!');
+    } catch (err) {
+      assert.equal(err.message, 'Not Found!');
+    }
+  });
+});


### PR DESCRIPTION
Hi!  I've added support for passing the knex transaction object through to knex as jmdobry described in [this comment](https://github.com/js-data/js-data-sql/issues/10#issuecomment-118668204) on issue #10.  It appears to work pretty well.

I added co to the development dependencies because I couldn't figure out how to reconcile co-mocha's use of generators and knex's use of the transaction callback.  I'm new to modern JavaScript -- particularly node.js and ES6 -- and I don't quite feel as though I know when best to use promises versus generators versus try/catch, so there may be a better way to implement my tests.

Thank you for js-data and everyone's assistance on Gitter.  Fantastic community.